### PR TITLE
Correct destination field assignment and add StatefulSet/bare pods

### DIFF
--- a/crd/controllers/inner/continuous_mode_controller.go
+++ b/crd/controllers/inner/continuous_mode_controller.go
@@ -126,8 +126,8 @@ func withDeploymentInformation(client kubernetes.Interface, output v12.ProbeOutp
 	dst, dst_in_state := lo.Find(curr_state, func(item v12.ProbeOutputItem) bool { return item.Source.Name == output.Destination.Name })
 	dst_2, dst_in_state_2 := lo.Find(curr_state, func(item v12.ProbeOutputItem) bool { return item.Destination.Name == output.Destination.Name })
 	if dst_in_state {
-		output.Source.ReplicaSetName = dst.Source.ReplicaSetName
-		output.Source.DeploymentName = dst.Source.DeploymentName
+		output.Destination.ReplicaSetName = dst.Source.ReplicaSetName
+		output.Destination.DeploymentName = dst.Source.DeploymentName
 	} else if dst_in_state_2 {
 		output.Destination.ReplicaSetName = dst_2.Destination.ReplicaSetName
 		output.Destination.DeploymentName = dst_2.Destination.DeploymentName

--- a/crd/controllers/utils/utils.go
+++ b/crd/controllers/utils/utils.go
@@ -111,19 +111,36 @@ func GetDeployment(replica v1.ReplicaSet) (string, error) {
 }
 
 func GetReplicaAndDeployment(client kubernetes.Interface, pod k8sAPI.Pod) (string, string) {
-	if replicaSetName, err := GetReplicaSet(pod); err != nil {
-		return "", ""
-	} else {
+	if replicaSetName, err := GetReplicaSet(pod); err == nil {
 		replicaSet, err := client.AppsV1().ReplicaSets(pod.Namespace).Get(context.TODO(), replicaSetName, metav1.GetOptions{})
 		if err != nil {
 			return replicaSetName, ""
 		}
-		if deployment, err2 := GetDeployment(*replicaSet); err2 != nil {
-			return replicaSetName, ""
-		} else {
+		if deployment, err2 := GetDeployment(*replicaSet); err2 == nil {
 			return replicaSetName, deployment
 		}
+		return replicaSetName, ""
 	}
+
+	if statefulSetName, err := GetStatefulSet(pod); err == nil {
+		return statefulSetName, statefulSetName
+	}
+
+	return "", pod.Name
+}
+
+func GetStatefulSet(pod k8sAPI.Pod) (string, error) {
+	refs := pod.OwnerReferences
+	ssRefs := lo.Filter(refs, func(ref metav1.OwnerReference, idx int) bool {
+		return ref.Kind == "StatefulSet"
+	})
+	names := lo.Map(ssRefs, func(ref metav1.OwnerReference, idx int) string {
+		return ref.Name
+	})
+	if len(names) == 1 {
+		return names[0], nil
+	}
+	return "", errors.New("no statefulset")
 }
 func GetReplicaSet(pod k8sAPI.Pod) (string, error) {
 


### PR DESCRIPTION
***Deux bugs faisaient que tous les pods affichaient le même `deploymentName` dans le graphe.***                                                                                                  
                                                                                                                                                                                              
  **Bug 1** : Dans `continuous_mode_controller.go`, une faute de copier-coller faisait que le nom de déploiement du pod destination était écrit dans `output.Source` au lieu de `output.Destination`. Du coup tous les pods prenaient le nom de la source.                                                                                                    
                                                                                                                   
  **Bug 2** : Dans `utils.go`, `GetReplicaAndDeployment` ne gérait pas les pods StatefulSet ni les pods bare. Ces pods retournaient juste des chaînes vides et n'apparaissaient pas correctement dans le graphe.                                                                                                 
                                                                                                                                       
***Fix  :***                                                                                                                                                                         
  - `continuous_mode_controller.go` : on écrit maintenant dans `output.Destination` au lieu de `output.Source`.                                                                               
  - `utils.go` : ajout de `GetStatefulSet()` et mise à jour de `GetReplicaAndDeployment` pour retomber sur le nom du StatefulSet, ou le nom du pod si rien d'autre n'est trouvé
    