### PR TITLE
Optimize probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,22 @@ spec:
   probe: all
 ```
 You can save it in a file `probe.yaml` and then apply it with `kubectl apply -f probe.yaml`
+### Tuning probe concurrency (optional)
+
+Kubesonde dispatches probes through a bounded worker pool. By default it runs **10** probes in parallel. You can override this with the `KUBESONDE_PROBE_WORKERS` environment variable on the controller (any positive integer; invalid or unset values fall back to the default of 10). Increase it to speed up probing on large namespaces, or lower it to reduce load on the cluster:
+
+```yaml
+env:
+  - name: KUBESONDE_PROBE_WORKERS
+    value: "20"
+```
+
+When running the controller locally (`make run`), export it before starting:
+
+```bash
+KUBESONDE_PROBE_WORKERS=20 make run
+```
+
 ### 4. Fetching the results
 
 To fetch the results, you need to use the following commands:

--- a/crd/controllers/dispatcher/probe_dispatcher.go
+++ b/crd/controllers/dispatcher/probe_dispatcher.go
@@ -28,6 +28,12 @@ var (
 	pq                  = make(PriorityQueue, 0, 1000)
 )
 
+// executeProbe runs a single probe command. It is a package-level variable so
+// that tests can substitute a fake executor to observe scheduling behaviour.
+var executeProbe = func(apiClient kubernetes.Interface, command probe_command.KubesondeCommand) {
+	inner.InspectAndStoreResult(apiClient, []probe_command.KubesondeCommand{command})
+}
+
 // Add probes to queue
 func SendToQueue(commands []probe_command.KubesondeCommand, priority Priority) {
 	if err := dispatcherSemaphore.Acquire(context.Background(), 1); err != nil {
@@ -77,7 +83,7 @@ func Run(apiClient kubernetes.Interface) {
 		dispatcherSemaphore.Release(1)
 
 		start := time.Now()
-		inner.InspectAndStoreResult(apiClient, []probe_command.KubesondeCommand{item.value})
+		executeProbe(apiClient, item.value)
 		duration := time.Since(start)
 		if duration < probeInterval {
 			time.Sleep(probeInterval - duration)

--- a/crd/controllers/dispatcher/probe_dispatcher.go
+++ b/crd/controllers/dispatcher/probe_dispatcher.go
@@ -6,6 +6,8 @@ import (
 	"container/heap"
 	"context"
 	"log"
+	"os"
+	"strconv"
 	"time"
 
 	"golang.org/x/sync/semaphore"
@@ -27,6 +29,22 @@ var (
 	dispatcherSemaphore = semaphore.NewWeighted(1)
 	pq                  = make(PriorityQueue, 0, 1000)
 )
+
+// defaultProbeWorkers is the number of probes executed concurrently. It is kept
+// modest to stay well within the kubelet's exec/attach concurrency limits.
+const defaultProbeWorkers = 10
+
+// probeWorkers reads the desired worker-pool size from the environment,
+// falling back to defaultProbeWorkers when unset or invalid.
+func probeWorkers() int {
+	if raw := os.Getenv("KUBESONDE_PROBE_WORKERS"); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil && n > 0 {
+			return n
+		}
+		dispatcherLog.Printf("Invalid KUBESONDE_PROBE_WORKERS=%q, using default %d", raw, defaultProbeWorkers)
+	}
+	return defaultProbeWorkers
+}
 
 // executeProbe runs a single probe command. It is a package-level variable so
 // that tests can substitute a fake executor to observe scheduling behaviour.
@@ -65,28 +83,65 @@ func QueueSize() int {
 	return size
 }
 
-// Main routine. Starts the probe running loop.
-func Run(apiClient kubernetes.Interface) {
-	const probeInterval = 50 * time.Millisecond
-	heap.Init(&pq)
-	for {
-		if err := dispatcherSemaphore.Acquire(context.Background(), 1); err != nil {
-			dispatcherLog.Printf("Failed to acquire semaphore: %v", err)
-			continue
-		}
-		if pq.Len() == 0 {
-			dispatcherSemaphore.Release(1)
-			time.Sleep(probeInterval)
-			continue
-		}
-		item := heap.Pop(&pq).(*Item)
-		dispatcherSemaphore.Release(1)
+// popNext removes and returns the highest-priority probe from the queue.
+// The boolean is false when the queue is empty. Access to the shared heap is
+// serialised through dispatcherSemaphore, which also guards SendToQueue.
+func popNext() (*Item, bool) {
+	if err := dispatcherSemaphore.Acquire(context.Background(), 1); err != nil {
+		dispatcherLog.Printf("Failed to acquire semaphore: %v", err)
+		return nil, false
+	}
+	defer dispatcherSemaphore.Release(1)
 
-		start := time.Now()
-		executeProbe(apiClient, item.value)
-		duration := time.Since(start)
-		if duration < probeInterval {
-			time.Sleep(probeInterval - duration)
+	if pq.Len() == 0 {
+		return nil, false
+	}
+	return heap.Pop(&pq).(*Item), true
+}
+
+// Run starts the probe worker pool. Probes are executed concurrently by a
+// bounded number of workers (see KUBESONDE_PROBE_WORKERS) that all drain the
+// shared priority queue. Workers run until ctx is cancelled.
+//
+// Run must be started only once for the shared queue; the caller is responsible
+// for that (see the reconciler, which guards startup with sync.Once).
+func Run(ctx context.Context, apiClient kubernetes.Interface) {
+	// Initialise the heap under the same lock that guards all other queue
+	// access, so it cannot race with a concurrent SendToQueue.
+	if err := dispatcherSemaphore.Acquire(ctx, 1); err != nil {
+		dispatcherLog.Printf("Failed to acquire semaphore: %v", err)
+		return
+	}
+	heap.Init(&pq)
+	dispatcherSemaphore.Release(1)
+
+	workers := probeWorkers()
+	dispatcherLog.Printf("Starting probe dispatcher with %d workers", workers)
+	for i := 0; i < workers; i++ {
+		go worker(ctx, apiClient)
+	}
+}
+
+// worker continuously drains the queue and executes probes until ctx is
+// cancelled. When the queue is empty it backs off briefly to avoid busy-spinning.
+func worker(ctx context.Context, apiClient kubernetes.Interface) {
+	const idleBackoff = 50 * time.Millisecond
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
 		}
+
+		item, ok := popNext()
+		if !ok {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(idleBackoff):
+			}
+			continue
+		}
+		executeProbe(apiClient, item.value)
 	}
 }

--- a/crd/controllers/dispatcher/probe_dispatcher_test.go
+++ b/crd/controllers/dispatcher/probe_dispatcher_test.go
@@ -1,7 +1,7 @@
 package dispatcher
 
 import (
-	"container/heap"
+	"context"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -43,21 +43,18 @@ var _ = Describe("SendToQueue", func() {
 		SendToQueue(commands, LOW)
 
 		// THEN
-		result := heap.Pop(&pq).(*Item).value
-		Expect(result).To(Equal(command))
-		Expect(pq.Len()).To(Equal(0))
+		item, ok := popNext()
+		Expect(ok).To(BeTrue())
+		Expect(item.value).To(Equal(command))
+		Expect(QueueSize()).To(Equal(0))
 	})
 })
 
-// This test documents the bottleneck described in finding #1: the dispatcher
-// executes probes strictly one-at-a-time. With N independent probes that each
-// take a fixed amount of time, a concurrent dispatcher would run them in
-// parallel (observed max concurrency > 1, wall time ~= single probe duration),
-// whereas the serial dispatcher runs them back-to-back (max concurrency == 1,
-// wall time ~= N * probe duration).
-//
-// It is RED against the current serial implementation and should turn GREEN
-// once the dispatcher runs probes through a bounded worker pool.
+// This test guards against the bottleneck described in finding #1: the
+// dispatcher must not execute probes strictly one-at-a-time. With N independent
+// probes that each take a fixed amount of time, the bounded worker pool runs
+// them in parallel (observed max concurrency > 1). Against the previous serial
+// implementation max concurrency was always 1 and this test failed.
 var _ = Describe("Run executes probes concurrently", func() {
 	It("runs independent probes in parallel", func() {
 		const (
@@ -104,7 +101,9 @@ var _ = Describe("Run executes probes concurrently", func() {
 		}
 
 		client := testclient.NewSimpleClientset()
-		go Run(client)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel() // stop the worker pool when the spec ends
+		Run(ctx, client)
 		SendToQueue(commands, LOW)
 
 		// Wait for all probes to be executed (generously).

--- a/crd/controllers/dispatcher/probe_dispatcher_test.go
+++ b/crd/controllers/dispatcher/probe_dispatcher_test.go
@@ -2,10 +2,16 @@ package dispatcher
 
 import (
 	"container/heap"
+	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/client-go/kubernetes"
+	testclient "k8s.io/client-go/kubernetes/fake"
 	v1 "kubesonde.io/api/v1"
 	"kubesonde.io/controllers/probe_command"
 )
@@ -40,6 +46,74 @@ var _ = Describe("SendToQueue", func() {
 		result := heap.Pop(&pq).(*Item).value
 		Expect(result).To(Equal(command))
 		Expect(pq.Len()).To(Equal(0))
+	})
+})
+
+// This test documents the bottleneck described in finding #1: the dispatcher
+// executes probes strictly one-at-a-time. With N independent probes that each
+// take a fixed amount of time, a concurrent dispatcher would run them in
+// parallel (observed max concurrency > 1, wall time ~= single probe duration),
+// whereas the serial dispatcher runs them back-to-back (max concurrency == 1,
+// wall time ~= N * probe duration).
+//
+// It is RED against the current serial implementation and should turn GREEN
+// once the dispatcher runs probes through a bounded worker pool.
+var _ = Describe("Run executes probes concurrently", func() {
+	It("runs independent probes in parallel", func() {
+		const (
+			numProbes     = 10
+			probeDuration = 100 * time.Millisecond
+		)
+
+		var (
+			inFlight    int32
+			maxInFlight int32
+		)
+
+		var wg sync.WaitGroup
+		wg.Add(numProbes)
+
+		// Substitute a slow fake executor that records peak concurrency.
+		original := executeProbe
+		defer func() { executeProbe = original }()
+		executeProbe = func(_ kubernetes.Interface, _ probe_command.KubesondeCommand) {
+			defer wg.Done()
+			cur := atomic.AddInt32(&inFlight, 1)
+			for {
+				old := atomic.LoadInt32(&maxInFlight)
+				if cur <= old || atomic.CompareAndSwapInt32(&maxInFlight, old, cur) {
+					break
+				}
+			}
+			time.Sleep(probeDuration)
+			atomic.AddInt32(&inFlight, -1)
+		}
+
+		// Enqueue N distinct probes.
+		commands := make([]probe_command.KubesondeCommand, 0, numProbes)
+		for i := 0; i < numProbes; i++ {
+			commands = append(commands, probe_command.KubesondeCommand{
+				Destination:     "test-destination",
+				DestinationPort: fmt.Sprintf("%d", 8000+i),
+				SourcePodName:   "test-pod",
+				ContainerName:   "debugger",
+				Namespace:       "default",
+				Command:         "sample command",
+				Action:          v1.ALLOW,
+			})
+		}
+
+		client := testclient.NewSimpleClientset()
+		go Run(client)
+		SendToQueue(commands, LOW)
+
+		// Wait for all probes to be executed (generously).
+		done := make(chan struct{})
+		go func() { wg.Wait(); close(done) }()
+		Eventually(done, 10*time.Second).Should(BeClosed())
+
+		Expect(atomic.LoadInt32(&maxInFlight)).To(BeNumerically(">", int32(1)),
+			"probes ran serially (max concurrency == 1); dispatcher does not parallelise")
 	})
 })
 

--- a/crd/internal/controller/kubesonde_controller.go
+++ b/crd/internal/controller/kubesonde_controller.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	kubesondev1 "kubesonde.io/api/v1"
@@ -34,6 +35,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
+
+// dispatcherOnce ensures the probe worker pool is started only once, regardless
+// of how many times Reconcile runs.
+var dispatcherOnce sync.Once
 
 // KubesondeReconciler reconciles a Kubesonde object
 type KubesondeReconciler struct {
@@ -64,8 +69,11 @@ func (r *KubesondeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		2) Handle resource deletion. When a kubesonde resource is removed, the state should be cleared
 	*/
 
-	// Dispatcher
-	go kubesondeDispatcher.Run(apiClient)
+	// Dispatcher. Start the worker pool only once across reconciles; it drains a
+	// process-wide shared queue and must not be started multiple times.
+	dispatcherOnce.Do(func() {
+		go kubesondeDispatcher.Run(context.Background(), apiClient)
+	})
 
 	// Events
 	go kubesondeEvents.InitEventListener(apiClient, Kubesonde)


### PR DESCRIPTION
## Summary

Probes were dispatched **strictly serially**: a single loop pulled one command off the priority queue, ran it to completion (an exec into a pod running nmap/wget/nslookup — hundreds of milliseconds each), and only then pulled the next. On a namespace with many pods this made total probing time scale linearly with the number of probes, even though the probes are independent and the cluster can easily handle many in parallel.

This PR replaces the serial dispatcher with a **bounded worker pool** so independent probes run concurrently.

## Changes

- **Parallel dispatcher** (`crd/controllers/dispatcher/probe_dispatcher.go`): `Run` now starts a pool of workers that each pop from the shared priority queue and execute probes concurrently. Queue access stays guarded so scheduling order and thread-safety are preserved.
- **Configurable concurrency**: worker count defaults to **10** and can be overridden with the `KUBESONDE_PROBE_WORKERS` environment variable (any positive integer; invalid/unset falls back to the default).
- **Context-aware shutdown**: `Run`/workers accept a `context.Context` and stop cleanly on cancellation.
- **Single startup**: the dispatcher is started once from the reconciler (`sync.Once`) since it drains a process-wide queue and must not be started per-reconcile.
- **Injectable executor seam**: the probe execution call is a package-level var so tests can substitute a fake executor and observe scheduling.

## Testing

- Added a **RED→GREEN concurrency test** that enqueues N independent probes with a fake executor that records peak in-flight concurrency. Against the old serial code max concurrency was always 1 (test fails); with the worker pool it observes >1.
- `go build ./...`, `go test ./...`, and `go test -race ./controllers/dispatcher/` all pass.
- Verified end-to-end on minikube + Bookinfo: controller logs `Starting probe dispatcher with 10 workers`, injects ephemeral containers into all pods, and produces the full pod→pod connectivity map (228 probes, 0 errors) noticeably faster.

## Docs

- README: new "Tuning probe concurrency" section documenting `KUBESONDE_PROBE_WORKERS`.
