### PR TITLE
Fix release workflow: attach installer, generate notes, order builds

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,26 @@
+# Configures the automatically generated release notes
+# (used by `generate_release_notes: true` in the release workflow).
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - dependabot
+  categories:
+    - title: 🚀 Features
+      labels:
+        - enhancement
+        - feature
+    - title: 🐛 Bug Fixes
+      labels:
+        - bug
+        - fix
+    - title: 📖 Documentation
+      labels:
+        - documentation
+    - title: ⬆️ Dependencies
+      labels:
+        - dependencies
+    - title: 🔧 Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/go_main.yaml
+++ b/.github/workflows/go_main.yaml
@@ -1,21 +1,18 @@
-name: Deploy containers
+name: Release
 
 on:
   push:
     tags:
       - 'v*'
-    paths:
-      - crd/**
-      - .github/**
 
 permissions:
   contents: write
   packages: write
 
 jobs:
+  # Build and test the CRD before releasing anything.
   prepare:
     uses: kubesonde/kubesonde/.github/workflows/go_base.yaml@main
-
 
   build-and-publish:
     runs-on: ubuntu-latest
@@ -29,38 +26,49 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: crd/go.mod
-          
+
+      - name: Resolve tag
+        id: tag
+        run: echo "name=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+
+      # Generate the installer manifest (repo-root kubesonde.yaml) pinned to the
+      # released controller image tag.
       - name: Create artifact
         working-directory: crd
-        run: TAG_NAME=${GITHUB_REF#refs/tags/} make artifact IMG=ghcr.io/kubesonde/controller:${TAG_NAME}
-
-      - name: Create Release
-        id: create_release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ github.ref }}  # Use the tag that triggered the workflow
-          files: crd/kubesonde.yaml
+        run: make artifact IMG=ghcr.io/kubesonde/controller:${{ steps.tag.outputs.name }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        
+        uses: docker/setup-buildx-action@v3
+
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-          
-      - name: Build controller with tag
+
+      # Push images first so the released manifest always points at an image that
+      # actually exists in the registry.
+      - name: Build controller image (tag + latest)
         working-directory: crd
-        run: make docker-buildx IMG=ghcr.io/kubesonde/controller:${GITHUB_REF#refs/tags/}
-      - name: Build controller with latest
-        working-directory: crd
-        run: make docker-buildx IMG=ghcr.io/kubesonde/controller:latest
-      
-      - name: Build gonetstat with tag
+        run: |
+          make docker-buildx IMG=ghcr.io/kubesonde/controller:${{ steps.tag.outputs.name }}
+          make docker-buildx IMG=ghcr.io/kubesonde/controller:latest
+
+      - name: Build gonetstat image (tag + latest)
         working-directory: docker
-        run: make IMG=ghcr.io/kubesonde/gonetstat:${GITHUB_REF#refs/tags/}
-      - name: Build gonetstat with latest
-        working-directory: docker
-        run: make IMG=ghcr.io/kubesonde/gonetstat:latest
+        run: |
+          make IMG=ghcr.io/kubesonde/gonetstat:${{ steps.tag.outputs.name }}
+          make IMG=ghcr.io/kubesonde/gonetstat:latest
+
+      # Create the GitHub Release last, attaching the installer manifest and
+      # auto-generated release notes from merged PRs / commits since the last tag.
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ steps.tag.outputs.name }}
+          generate_release_notes: true
+          prerelease: ${{ contains(steps.tag.outputs.name, '-') }}
+          fail_on_unmatched_files: true
+          files: kubesonde.yaml

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,49 @@
+# Releasing Kubesonde
+
+Releases are fully automated and triggered by pushing a Git tag that starts with
+`v` (for example `v0.9.0`). The [`Release` workflow](.github/workflows/go_main.yaml)
+then:
+
+1. Builds and tests the CRD (via the reusable `go_base.yaml` workflow).
+2. Generates the installer manifest `kubesonde.yaml`, pinned to the released
+   controller image tag.
+3. Builds and pushes multi-arch images to GHCR:
+   - `ghcr.io/kubesonde/controller:<tag>` and `:latest`
+   - `ghcr.io/kubesonde/gonetstat:<tag>` and `:latest`
+4. Creates a GitHub Release with **auto-generated release notes** (categorized
+   via [`.github/release.yml`](.github/release.yml)) and attaches
+   `kubesonde.yaml` as a downloadable asset.
+
+Images are pushed **before** the Release is created, so a published release
+always points at images that exist in the registry.
+
+## Cutting a release
+
+```bash
+# Make sure main is green and up to date, then:
+git checkout main && git pull
+
+# Tag and push. Use a semver tag prefixed with v.
+git tag v0.9.0
+git push origin v0.9.0
+```
+
+That's it — the workflow does the rest. Watch it under the repository's
+**Actions** tab.
+
+## Pre-releases
+
+Any tag containing a hyphen is automatically marked as a **pre-release** on
+GitHub (it still builds and pushes images):
+
+```bash
+git tag v0.9.0-rc.1
+git push origin v0.9.0-rc.1
+```
+
+## Nicer release notes
+
+Release notes are grouped by pull-request labels (Features, Bug Fixes,
+Documentation, Dependencies, …). Label your PRs accordingly to get a clean
+changelog. Dependabot PRs and anything labelled `ignore-for-release` are
+excluded.

--- a/crd/Makefile
+++ b/crd/Makefile
@@ -185,10 +185,10 @@ $(GOLANGCI_LINT): $(LOCALBIN)
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,${GOLANGCI_LINT_VERSION})
 
 .PHONY: artifact
-artifact: manifests
+artifact: manifests kustomize ## Generate the repo-root kubesonde.yaml installer manifest pinned to IMG.
 	echo "Creating controller"
-	cd config/manager && kustomize edit set image controller=${IMG}
-	kustomize build config/default > ../kubesonde.yaml
+	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	$(KUSTOMIZE) build config/default > ../kubesonde.yaml
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary (ideally with version)


### PR DESCRIPTION
The release job uploaded crd/kubesonde.yaml but `make artifact` writes the manifest to the repo root, so releases attached a nonexistent file. Fix the path and fail the job if the asset is missing.

- Upload repo-root kubesonde.yaml; set fail_on_unmatched_files
- Enable auto-generated, label-categorized release notes (.github/release.yml)
- Build and push images before creating the release so the released manifest always points at images that exist
- Drop the paths filter that can suppress tag-triggered runs
- Auto-mark hyphenated tags (e.g. v0.9.0-rc.1) as pre-releases
- Make `make artifact` use the Makefile-managed kustomize instead of a bare binary that may be absent in CI
- Add RELEASING.md documenting the process
