### PR TITLE
Add CodeQL code scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,46 @@
+name: CodeQL
+
+# Automated security/quality code scanning for the Go controller. Results appear
+# in the repository's Security > Code scanning tab and inline on pull requests.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly full scan (Mondays 06:00 UTC) to catch newly published advisories.
+    - cron: "0 6 * * 1"
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (go)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: crd/go.mod
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: go
+          build-mode: manual
+
+      # go.mod lives in crd/, so build explicitly instead of relying on autobuild.
+      - name: Build
+        working-directory: crd
+        run: make build
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:go"


### PR DESCRIPTION
## Summary

Adds free automated code review via **CodeQL** security/quality scanning for the Go controller.

## Details

- Runs on push and pull_request to `main`, plus a weekly scheduled scan (catches newly published advisories).
- Uses `build-mode: manual` with `make build`, since `go.mod` lives under `crd/` and autobuild is unreliable for subdirectory modules.
- Results appear in **Security > Code scanning** and inline on PRs.
- Free for this public repository; no external accounts or API keys.

Complements the existing `gosec` SARIF upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
