### PR TITLE
feat(frontend): containerize kubesonde frontend

### DIFF
--- a/.github/workflows/frontend_container.yaml
+++ b/.github/workflows/frontend_container.yaml
@@ -1,0 +1,45 @@
+name: Build and push frontend container
+
+on:
+  push:
+    tags:
+      - "v*"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/frontend
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./frontend
+          file: ./frontend/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/crd/config/default/kustomization.yaml
+++ b/crd/config/default/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
 - ../crd
 - ../rbac
 - ../manager
+- ../frontend
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 #- ../webhook

--- a/crd/config/frontend/frontend.yaml
+++ b/crd/config/frontend/frontend.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  labels:
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/component: frontend
+    app.kubernetes.io/part-of: kubesonde
+    app.kubernetes.io/managed-by: kustomize
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: frontend
+      app.kubernetes.io/part-of: kubesonde
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: frontend
+        app.kubernetes.io/part-of: kubesonde
+    spec:
+      securityContext:
+        runAsNonRoot: true
+      containers:
+      # The controller REST API URL (http://localhost:2709) is baked into the
+      # image at build time; the browser reaches it via
+      # `kubectl port-forward ... 2709:2709`.
+      - name: frontend
+        image: ghcr.io/kubesonde/frontend:latest
+        ports:
+        - containerPort: 8088
+          name: http
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 8088
+          initialDelaySeconds: 10
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8088
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 200m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsUser: 65534
+          capabilities:
+            drop:
+            - ALL
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubesonde-frontend
+  labels:
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/component: frontend
+    app.kubernetes.io/part-of: kubesonde
+    app.kubernetes.io/managed-by: kustomize
+spec:
+  selector:
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/part-of: kubesonde
+  ports:
+  - name: http
+    port: 8088
+    targetPort: 8088

--- a/crd/config/frontend/kustomization.yaml
+++ b/crd/config/frontend/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- frontend.yaml

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,24 @@
+# Build the Vite app
+FROM node:24.20.0-alpine AS build
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm install
+COPY . .
+
+ARG VITE_API_SERVER=http://localhost:2709
+ENV VITE_API_SERVER=$VITE_API_SERVER
+
+RUN VITE_APP_VERSION="$(node -p "require('./package.json').version")" npm run build
+
+# Serve the static SPA with nginx
+
+FROM nginxinc/nginx-unprivileged:alpine
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/build /usr/share/nginx/html
+# Run as an unprivileged user. Make nginx's writable dirs owned by nobody so it
+# can create its temp/pid files without root.
+USER root
+RUN chown -R nobody /var/cache/nginx /tmp
+USER nobody
+EXPOSE 8088
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,12 @@
+server {
+    listen 8088;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # SPA routing: fall back to index.html so react-router deep links work
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## What

Containerizes the Kubesonde frontend and deploys it alongside the controller via a single `kubectl apply`.

## Changes

- **`frontend/Dockerfile`** — multi-stage build: Vite build on `node:24.20.0-alpine`, served by `nginxinc/nginx-unprivileged:alpine`. Runs as `nobody`, listens on `8088` (8080 is taken by the controller's metrics endpoint). Bakes `VITE_API_SERVER=http://localhost:2709` and `VITE_APP_VERSION` (from `package.json`, mirroring the Netlify build) into the bundle at build time.
- **`frontend/nginx.conf`** — SPA config: `listen 8088` with `try_files … /index.html` fallback so react-router deep links resolve.
- **`.github/workflows/frontend_container.yaml`** — on `v*` tag pushes, builds and pushes `ghcr.io/kubesonde/frontend` (semver + `latest`) to GHCR using the built-in `GITHUB_TOKEN`.
- **`crd/config/frontend/`** — kustomize base with a standalone frontend `Deployment` (its own pod, `runAsUser: 65534`) + `Service` on 8088.
- **`crd/config/default/kustomization.yaml`** — includes `../frontend`, so the frontend is part of the generated installer.
- **`kubesonde.yaml`** — regenerated via `make artifact` / `kustomize build config/default`.

## Usage

```
kubectl apply -f kubesonde.yaml
kubectl -n kubesonde-system port-forward svc/kubesonde-frontend 8088:8088
kubectl -n kubesonde-system port-forward deploy/kubesonde-controller-manager 2709:2709
# open http://localhost:8088
```

## Verification

- Clean `--no-cache` image build; runs as `nobody` (uid 65534); `GET /` → 200; no nginx errors.
- API URL and app version confirmed baked into the bundle.
- `kustomize build config/default` renders two separate pods (controller + frontend).
- All 56 frontend jest tests pass.

## Notes

- First GHCR publish creates the package as **private** — flip it to public for anonymous pulls.
